### PR TITLE
🩹 [Patch]: Default behavior is to use the `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/Action-Test.yml
+++ b/.github/workflows/Action-Test.yml
@@ -41,6 +41,29 @@ jobs:
               "This is a group"
             }
 
+  ActionTestWithGitHubToken:
+    name: Action-Test - [WithGitHubToken]
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      # Need to check out as part of the test, as its a local action
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Action-Test
+        uses: ./
+        with:
+          Verbose: true
+          Script: |
+            LogGroup "Get-GitHubZen" {
+              Get-GitHubZen
+            }
+
+            LogGroup "Get-GitHubOctocat" {
+              Get-GitHubOctocat
+            }
+
   ActionTestWithToken:
     name: Action-Test - [WithToken]
     runs-on: ubuntu-latest
@@ -62,6 +85,7 @@ jobs:
             LogGroup "Get-GitHubOctocat" {
               Get-GitHubOctocat
             }
+
 
   ActionTestWithVersion:
     name: Action-Test - [WithVersion]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ For more information on the available functions and automatic loaded variables, 
 | Name | Description | Required | Default |
 | - | - | - | - |
 | `Script` | The script to run | false | |
-| `Token` | The GitHub token to use | false | `${{ github.token }}` |
+| `Token` | The GitHub token to use. This will override the default behavior of using the `GITHUB_TOKEN` environment variable. | false | `${{ github.token }}` |
 | `Debug` | Enable debug output | false | `'false'` |
 | `Verbose` | Enable verbose output | false | `'false'` |
 | `Version` | Specifies the version of the GitHub module to be installed. The value must be an exact version. | false | |

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ inputs:
     description: The script to run.
     required: false
   Token:
-    description: The GitHub token to use.
+    description: The GitHub token to use. This will override the default behavior of using the `GITHUB_TOKEN` environment variable.
     required: false
   Debug:
     description: Enable debug output.

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,7 @@ runs:
       shell: pwsh
       working-directory: ${{ inputs.WorkingDirectory }}
       env:
-        GITHUB_TOKEN: ${{ inputs.Token }}
+        GITHUB_ACTION_INPUT_Token: ${{ inputs.Token }}
         GITHUB_ACTION_INPUT_Debug: ${{ inputs.Debug }}
         GITHUB_ACTION_INPUT_Verbose: ${{ inputs.Verbose }}
         GITHUB_ACTION_INPUT_Version: ${{ inputs.Version }}

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -5,6 +5,11 @@ $Name = 'GitHub'
 $Version = [string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Version) ? $null : $env:GITHUB_ACTION_INPUT_Version
 $Prerelease = $env:GITHUB_ACTION_INPUT_Prerelease -eq 'true'
 
+if (-not [string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Token)) {
+    Write-Verbose "Setting GITHUB_TOKEN to provided input 'Token'"
+    $env:GITHUB_TOKEN = $env:GITHUB_ACTION_INPUT_Token
+}
+
 $alreadyInstalled = Get-InstalledPSResource -Name $Name -ErrorAction SilentlyContinue
 if ($Version) {
     Write-Verbose "Filtering by version: $Version"


### PR DESCRIPTION
## Description

- Default behavior is to use the `GITHUB_TOKEN` if not `Token` is provided.
  - `GH_TOKEN` (EnvVar) > `GITHUB_TOKEN` (EnvVar) > `Token` (Input)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
