### PR TITLE
🩹 [Patch]: Add tests to verify that Get/Set-GitHubOutput handles objects and hashtables

### DIFF
--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -104,6 +104,10 @@ jobs:
               Set-GitHubOutput -Name 'Context' -Value (Get-GitHubContext)
             }
 
+            LogGroup 'Set outputs - GitConfig' {
+              Set-GitHubOutput -Name 'GitConfig' -Value (Get-GitHubGitConfig)
+            }
+
             LogGroup 'Set outputs - Zen2' {
               Set-GitHubOutput -Name 'Zen2' -Value $zen
             }

--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -105,7 +105,7 @@ jobs:
             }
 
             LogGroup 'Set outputs - GitConfig' {
-              Set-GitHubOutput -Name 'GitConfig' -Value (Get-GitHubGitConfig)
+              Set-GitHubOutput -Name 'GitConfig' -Value (Get-GitHubGitConfig | Where-Object { $_.Key -eq 'user.name' -or $_.Key -eq 'user.email' })
             }
 
             LogGroup 'Set outputs - Zen2' {

--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -121,9 +121,9 @@ jobs:
           $result = $env:result | ConvertFrom-Json
           Set-GitHubStepSummary -Summary $env:WISECAT
           Write-GitHubNotice -Message $result.Zen -Title 'GitHub Zen'
-          $result.Context | Format-Table -AutoSize
-          $result.GitConfig | Format-Table -AutoSize
           Write-Host ($result.Zen2)
+          $result.Context | Format-List
+          $result.GitConfig | Format-List
 
   ActionTestWithoutToken:
     name: WithoutToken

--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -105,7 +105,7 @@ jobs:
             }
 
             LogGroup 'Set outputs - GitConfig' {
-              Set-GitHubOutput -Name 'GitConfig' -Value (Get-GitHubGitConfig | Where-Object { $_.Key -eq 'user.name' -or $_.Key -eq 'user.email' })
+              Set-GitHubOutput -Name 'GitConfig' -Value (Get-GitHubGitConfig | Where-Object { $_.Name -in 'user.name','user.email' })
             }
 
             LogGroup 'Set outputs - Zen2' {

--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -92,12 +92,20 @@ jobs:
               Set-GitHubEnvironmentVariable -Name 'OCTOCAT' -Value $cat
             }
 
-            LogGroup 'Set outputs WISECAT' {
+            LogGroup 'Set outputs - WISECAT' {
               Set-GitHubOutput -Name 'WISECAT' -Value $cat
             }
 
-            LogGroup 'Set outputs Zen' {
+            LogGroup 'Set outputs - Zen' {
               Set-GitHubOutput -Name 'Zen' -Value $zen
+            }
+
+            LogGroup 'Set outputs - Context' {
+              Set-GitHubOutput -Name 'Context' -Value (Get-GitHubContext)
+            }
+
+            LogGroup 'Set outputs - Zen2' {
+              Set-GitHubOutput -Name 'Zen2' -Value $zen
             }
 
       - name: Run-test

--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -121,6 +121,9 @@ jobs:
           $result = $env:result | ConvertFrom-Json
           Set-GitHubStepSummary -Summary $env:WISECAT
           Write-GitHubNotice -Message $result.Zen -Title 'GitHub Zen'
+          $result.Context | Format-Table -AutoSize
+          $result.GitConfig | Format-Table -AutoSize
+          Write-Host ($result.Zen2)
 
   ActionTestWithoutToken:
     name: WithoutToken


### PR DESCRIPTION
## Description

This pull request adds tests for the Get/Set-GitHubOutput function to validate that they manage objects and hashtables as expected.

### Improvements to logging and output settings:

* Added new log groups to set outputs for `Context` and `GitConfig` in the workflow. 
* Modified existing log group names to include hyphens for better readability. 

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
