### PR TITLE
🩹 [Patch]: Add GH Auth status if not App context

### DIFF
--- a/scripts/info.ps1
+++ b/scripts/info.ps1
@@ -26,6 +26,9 @@ process {
 
         LogGroup ' - GitHub connection - Default' {
             Get-GitHubContext | Format-List
+
+            Write-Output 'GitHub CLI status:'
+            gh auth status
         }
 
         LogGroup ' - GitHub connection - List' {

--- a/scripts/info.ps1
+++ b/scripts/info.ps1
@@ -29,6 +29,7 @@ process {
 
             Write-Output 'GitHub CLI status:'
             gh auth status
+            $LASTEXITCODE = 0
         }
 
         LogGroup ' - GitHub connection - List' {

--- a/scripts/info.ps1
+++ b/scripts/info.ps1
@@ -28,7 +28,7 @@ process {
             $context = Get-GitHubContext
             $context | Format-List
 
-            if ($context.AuthType -eq 'IAT') {
+            if ($context.AuthType -ne 'APP') {
                 Write-Output 'GitHub CLI status:'
                 gh auth status
                 $LASTEXITCODE = 0

--- a/scripts/info.ps1
+++ b/scripts/info.ps1
@@ -25,11 +25,14 @@ process {
         }
 
         LogGroup ' - GitHub connection - Default' {
-            Get-GitHubContext | Format-List
+            $context = Get-GitHubContext
+            $context | Format-List
 
-            Write-Output 'GitHub CLI status:'
-            gh auth status
-            $LASTEXITCODE = 0
+            if ($context.AuthType -eq 'IAT') {
+                Write-Output 'GitHub CLI status:'
+                gh auth status
+                $LASTEXITCODE = 0
+            }
         }
 
         LogGroup ' - GitHub connection - List' {

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -96,6 +96,8 @@ process {
             Connect-GitHub -ClientID $env:GITHUB_ACTION_INPUT_ClientID -PrivateKey $env:GITHUB_ACTION_INPUT_PrivateKey -Silent:(-not $showInit)
         } elseif ($providedToken) {
             Connect-GitHub -Token $env:GITHUB_ACTION_INPUT_Token -Silent:(-not $showInit)
+            $env:GITHUB_HOST_NAME = ($env:GITHUB_SERVER_URL ?? 'github.com') -replace '^https?://'
+            $env:GITHUB_ACTION_INPUT_Token | gh auth login --with-token --hostname $env:GITHUB_HOST_NAME
         }
         if ($showInit) {
             Write-Output '::endgroup::'

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -96,12 +96,6 @@ process {
             Connect-GitHub -ClientID $env:GITHUB_ACTION_INPUT_ClientID -PrivateKey $env:GITHUB_ACTION_INPUT_PrivateKey -Silent:(-not $showInit)
         } elseif ($providedToken) {
             Connect-GitHub -Token $env:GITHUB_ACTION_INPUT_Token -Silent:(-not $showInit)
-            Write-Output '::endgroup::'
-            Write-Output '::group:: - Connect to GitHub (gh cli)'
-            $env:GITHUB_HOST_NAME = ($env:GITHUB_SERVER_URL ?? 'github.com') -replace '^https?://'
-            $env:GITHUB_ACTION_INPUT_Token | gh auth login --with-token --hostname $env:GITHUB_HOST_NAME
-            gh auth status
-            gh auth setup-git
         }
         if ($showInit) {
             Write-Output '::endgroup::'

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -96,9 +96,12 @@ process {
             Connect-GitHub -ClientID $env:GITHUB_ACTION_INPUT_ClientID -PrivateKey $env:GITHUB_ACTION_INPUT_PrivateKey -Silent:(-not $showInit)
         } elseif ($providedToken) {
             Connect-GitHub -Token $env:GITHUB_ACTION_INPUT_Token -Silent:(-not $showInit)
+            Write-Output '::endgroup::'
+            Write-Output '::group:: - Connect to GitHub (gh cli)'
             $env:GITHUB_HOST_NAME = ($env:GITHUB_SERVER_URL ?? 'github.com') -replace '^https?://'
             $env:GITHUB_ACTION_INPUT_Token | gh auth login --with-token --hostname $env:GITHUB_HOST_NAME
             gh auth status
+            gh setup-git
         }
         if ($showInit) {
             Write-Output '::endgroup::'

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -98,6 +98,7 @@ process {
             Connect-GitHub -Token $env:GITHUB_ACTION_INPUT_Token -Silent:(-not $showInit)
             $env:GITHUB_HOST_NAME = ($env:GITHUB_SERVER_URL ?? 'github.com') -replace '^https?://'
             $env:GITHUB_ACTION_INPUT_Token | gh auth login --with-token --hostname $env:GITHUB_HOST_NAME
+            gh auth status
         }
         if ($showInit) {
             Write-Output '::endgroup::'

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -101,7 +101,7 @@ process {
             $env:GITHUB_HOST_NAME = ($env:GITHUB_SERVER_URL ?? 'github.com') -replace '^https?://'
             $env:GITHUB_ACTION_INPUT_Token | gh auth login --with-token --hostname $env:GITHUB_HOST_NAME
             gh auth status
-            gh setup-git
+            gh auth setup-git
         }
         if ($showInit) {
             Write-Output '::endgroup::'


### PR DESCRIPTION
## Description

This pull request includes an enhancement to the GitHub connection logging process in the `scripts/info.ps1` file. The change ensures that the GitHub CLI authentication status is checked and displayed if the authentication type is not 'APP'.

Improvements to GitHub connection logging:

* [`scripts/info.ps1`](diffhunk://#diff-82c586f67d16e32953b47a962c269d0a484f8aa660d71ad354e91fd2d4334cd9L28-R35): Modified the logging process to store the GitHub context in a variable and added a conditional check to display the GitHub CLI authentication status when the authentication type is not 'APP'.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
