### PR TITLE
🩹 [Patch]: Update environment variable prefixes for GitHub script inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,16 +64,16 @@ runs:
       id: RunGitHubScript
       working-directory: ${{ inputs.WorkingDirectory }}
       env:
-        GITHUB_ACTION_INPUT_Token: ${{ inputs.Token }}
-        GITHUB_ACTION_INPUT_ClientID: ${{ inputs.ClientID }}
-        GITHUB_ACTION_INPUT_PrivateKey: ${{ inputs.PrivateKey }}
-        GITHUB_ACTION_INPUT_Debug: ${{ inputs.Debug }}
-        GITHUB_ACTION_INPUT_Verbose: ${{ inputs.Verbose }}
-        GITHUB_ACTION_INPUT_Version: ${{ inputs.Version }}
-        GITHUB_ACTION_INPUT_ShowInit: ${{ inputs.ShowInit }}
-        GITHUB_ACTION_INPUT_ShowInfo: ${{ inputs.ShowInfo }}
-        GITHUB_ACTION_INPUT_ShowOutput: ${{ inputs.ShowOutput }}
-        GITHUB_ACTION_INPUT_Prerelease: ${{ inputs.Prerelease }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_Token: ${{ inputs.Token }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_ClientID: ${{ inputs.ClientID }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_PrivateKey: ${{ inputs.PrivateKey }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_Debug: ${{ inputs.Debug }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_Verbose: ${{ inputs.Verbose }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_Version: ${{ inputs.Version }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_ShowInit: ${{ inputs.ShowInit }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_ShowInfo: ${{ inputs.ShowInfo }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_ShowOutput: ${{ inputs.ShowOutput }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_Prerelease: ${{ inputs.Prerelease }}
       run: |
         # GitHub-Script
         try {

--- a/scripts/info.ps1
+++ b/scripts/info.ps1
@@ -12,8 +12,8 @@ process {
     try {
         $fenceTitle = 'GitHub-Script'
 
-        Write-Debug "[$scriptName] - ShowInfo: $env:GITHUB_ACTION_INPUT_ShowInfo"
-        if ($env:GITHUB_ACTION_INPUT_ShowInfo -ne 'true') {
+        Write-Debug "[$scriptName] - ShowInfo: $env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowInfo"
+        if ($env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowInfo -ne 'true') {
             return
         }
 
@@ -28,11 +28,11 @@ process {
             $context = Get-GitHubContext
             $context | Format-List
 
-            Write-Verbose "Token?    [$([string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Token))]"
+            Write-Verbose "Token?    [$([string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token))]"
             Write-Verbose "AuthType? [$($context.AuthType)] - [$($context.AuthType -ne 'APP')]"
-            Write-Verbose "gh auth?  [$($context.AuthType -ne 'APP' -and -not [string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Token))]"
+            Write-Verbose "gh auth?  [$($context.AuthType -ne 'APP' -and -not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token))]"
 
-            if ($context.AuthType -ne 'APP' -and -not [string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Token)) {
+            if ($context.AuthType -ne 'APP' -and -not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token)) {
                 Write-Output 'GitHub CLI status:'
                 $before = $LASTEXITCODE
                 gh auth status
@@ -60,6 +60,6 @@ process {
 
 end {
     Write-Debug "[$scriptName] - End"
-    $DebugPreference = $env:GITHUB_ACTION_INPUT_Debug -eq 'true' ? 'Continue' : 'SilentlyContinue'
-    $VerbosePreference = $env:GITHUB_ACTION_INPUT_Verbose -eq 'true' ? 'Continue' : 'SilentlyContinue'
+    $DebugPreference = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Debug -eq 'true' ? 'Continue' : 'SilentlyContinue'
+    $VerbosePreference = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Verbose -eq 'true' ? 'Continue' : 'SilentlyContinue'
 }

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -93,9 +93,18 @@ process {
             Write-Output '::group:: - Connect to GitHub'
         }
         if ($providedClientID -and $providedPrivateKey) {
-            Connect-GitHub -ClientID $env:PSMODULE_GITHUB_SCRIPT_INPUT_ClientID -PrivateKey $env:PSMODULE_GITHUB_SCRIPT_INPUT_PrivateKey -Silent:(-not $showInit)
+            $params = @{
+                ClientID   = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ClientID
+                PrivateKey = $env:PSMODULE_GITHUB_SCRIPT_INPUT_PrivateKey
+                Silent     = (-not $showInit)
+            }
+            Connect-GitHub @params
         } elseif ($providedToken) {
-            Connect-GitHub -Token $env:PSMODULE_GITHUB_SCRIPT_INPUT_Token -Silent:(-not $showInit)
+            $params = @{
+                Token  = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Token
+                Silent = (-not $showInit)
+            }
+            Connect-GitHub @params
         }
         if ($showInit) {
             Write-Output '::endgroup::'

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -10,9 +10,9 @@ process {
     try {
         $env:PSMODULE_GITHUB_SCRIPT = $true
         $fenceTitle = 'GitHub-Script'
-        $showInit = $env:GITHUB_ACTION_INPUT_ShowInit -eq 'true'
+        $showInit = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowInit -eq 'true'
 
-        Write-Debug "[$scriptName] - ShowInit: $env:GITHUB_ACTION_INPUT_ShowInit"
+        Write-Debug "[$scriptName] - ShowInit: $env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowInit"
 
         if ($showInit) {
             $fenceStart = "┏━━┫ $fenceTitle - Init ┣━━━━━━━━┓"
@@ -20,8 +20,8 @@ process {
             Write-Output '::group:: - Install GitHub PowerShell module'
         }
         $Name = 'GitHub'
-        $Version = [string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Version) ? $null : $env:GITHUB_ACTION_INPUT_Version
-        $Prerelease = $env:GITHUB_ACTION_INPUT_Prerelease -eq 'true'
+        $Version = [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Version) ? $null : $env:PSMODULE_GITHUB_SCRIPT_INPUT_Version
+        $Prerelease = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Prerelease -eq 'true'
 
         $alreadyInstalled = Get-InstalledPSResource -Name $Name -ErrorAction SilentlyContinue
         if ($Version) {
@@ -73,9 +73,9 @@ process {
             Import-Module -Name $Name
         }
 
-        $providedToken = -not [string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_Token)
-        $providedClientID = -not [string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_ClientID)
-        $providedPrivateKey = -not [string]::IsNullOrEmpty($env:GITHUB_ACTION_INPUT_PrivateKey)
+        $providedToken = -not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token)
+        $providedClientID = -not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_ClientID)
+        $providedPrivateKey = -not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_PrivateKey)
         $moduleStatus = [pscustomobject]@{
             Name                  = $Name
             Version               = [string]::IsNullOrEmpty($Version) ? 'latest' : $Version
@@ -93,9 +93,9 @@ process {
             Write-Output '::group:: - Connect to GitHub'
         }
         if ($providedClientID -and $providedPrivateKey) {
-            Connect-GitHub -ClientID $env:GITHUB_ACTION_INPUT_ClientID -PrivateKey $env:GITHUB_ACTION_INPUT_PrivateKey -Silent:(-not $showInit)
+            Connect-GitHub -ClientID $env:PSMODULE_GITHUB_SCRIPT_INPUT_ClientID -PrivateKey $env:PSMODULE_GITHUB_SCRIPT_INPUT_PrivateKey -Silent:(-not $showInit)
         } elseif ($providedToken) {
-            Connect-GitHub -Token $env:GITHUB_ACTION_INPUT_Token -Silent:(-not $showInit)
+            Connect-GitHub -Token $env:PSMODULE_GITHUB_SCRIPT_INPUT_Token -Silent:(-not $showInit)
         }
         if ($showInit) {
             Write-Output '::endgroup::'

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -11,8 +11,8 @@ Write-Debug "[$scriptName] - Start"
 try {
     $fenceTitle = 'GitHub-Script'
 
-    Write-Debug "[$scriptName] - ShowOutput: $env:GITHUB_ACTION_INPUT_ShowOutput"
-    if ($env:GITHUB_ACTION_INPUT_ShowOutput -ne 'true') {
+    Write-Debug "[$scriptName] - ShowOutput: $env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowOutput"
+    if ($env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowOutput -ne 'true') {
         return
     }
 


### PR DESCRIPTION
## Description

This pull request focuses on updating environment variable names across multiple scripts to ensure consistency and clarity. The changes involve renaming variables from `GITHUB_ACTION_INPUT_*` to `PSMODULE_GITHUB_SCRIPT_INPUT_*`. This is to reduce the change of clobbering the envvars for the GitHub-Script action. Aligns with a undocumented decision of having all inputs of actions and workflows as `<OWNER>_<REPO_NAME>_INPUT_*`.

- Fixes #36 

As this is internals of the action, this is deemed a patch update as nothing should rely on these variables apart from the scripts in the action.

* Updated environment variable names in `action.yml` to use the `PSMODULE_GITHUB_SCRIPT_INPUT_*` prefix.
* Modified `scripts/info.ps1` to reflect the new environment variable names for `ShowInfo`, `Token`, and `Debug` settings. [[1]](diffhunk://#diff-82c586f67d16e32953b47a962c269d0a484f8aa660d71ad354e91fd2d4334cd9L15-R16) [[2]](diffhunk://#diff-82c586f67d16e32953b47a962c269d0a484f8aa660d71ad354e91fd2d4334cd9L31-R35) [[3]](diffhunk://#diff-82c586f67d16e32953b47a962c269d0a484f8aa660d71ad354e91fd2d4334cd9L63-R64)
* Adjusted `scripts/init.ps1` to use the updated environment variable names for `ShowInit`, `Version`, `Prerelease`, `Token`, `ClientID`, and `PrivateKey`. [[1]](diffhunk://#diff-f47ceebe9ade2bb55cede031de8267e9c87b09336a93fcd557c02c1f488554b6L13-R24) [[2]](diffhunk://#diff-f47ceebe9ade2bb55cede031de8267e9c87b09336a93fcd557c02c1f488554b6L76-R78) [[3]](diffhunk://#diff-f47ceebe9ade2bb55cede031de8267e9c87b09336a93fcd557c02c1f488554b6L96-R98)
* Changed `scripts/outputs.ps1` to use the new environment variable name for `ShowOutput`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
