### PR TITLE
🩹 [Patch]: Update scripts to output as strings

### DIFF
--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -388,7 +388,6 @@ jobs:
           Token: ${{ secrets.TEST_USER_PAT }}
           Prerelease: ${{ inputs.Prerelease }}
           Script: |
-            $PSStyle.OutputRendering = 'Ansi'
             LogGroup 'Get-GitHubUser' {
               Get-GitHubUser | Format-Table -AutoSize | Out-String
             }
@@ -407,7 +406,6 @@ jobs:
           Token: ${{ secrets.TEST_USER_USER_FG_PAT }}
           Prerelease: ${{ inputs.Prerelease }}
           Script: |
-            $PSStyle.OutputRendering = 'Ansi'
             LogGroup 'Get-GitHubUser' {
               Get-GitHubUser | Format-Table -AutoSize | Out-String
             }
@@ -426,7 +424,6 @@ jobs:
           Token: ${{ secrets.TEST_USER_ORG_FG_PAT }}
           Prerelease: ${{ inputs.Prerelease }}
           Script: |
-            $PSStyle.OutputRendering = 'Ansi'
             LogGroup 'Get-GitHubUser' {
               Get-GitHubUser | Format-Table -AutoSize | Out-String
             }
@@ -446,7 +443,6 @@ jobs:
           PrivateKey: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
           Prerelease: ${{ inputs.Prerelease }}
           Script: |
-            $PSStyle.OutputRendering = 'Ansi'
             LogGroup 'Get-GitHubApp' {
               Get-GitHubApp | Format-Table -AutoSize | Out-String
             }

--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -230,13 +230,14 @@ jobs:
           ComplexArrayJson: ${{ fromJson(steps.test.outputs.result).ComplexArrayJson }}
         run: |
           $result = $env:result | ConvertFrom-Json
+          $PSStyle.OutputRendering = 'Ansi'
 
           LogGroup 'Result - Json' {
-            $env:result
+            $env:result | Format-List | Out-String
           }
 
           LogGroup 'Result - Object' {
-            $result
+            $result | Format-List | Out-String
           }
 
           LogGroup "WISECAT" {
@@ -248,11 +249,11 @@ jobs:
           }
 
           LogGroup "Context" {
-            $env:Context
+            $env:Context | Format-List | Out-String
           }
 
           LogGroup "GitConfig" {
-            $env:GitConfig
+            $env:GitConfig | Format-List | Out-String
           }
 
           LogGroup "Zen2" {
@@ -279,13 +280,13 @@ jobs:
               Set-GitHubStepSummary -Summary $env:WISECAT
               Write-GitHubNotice -Message $result.Zen -Title 'GitHub Zen'
               Write-Host ($result.Zen2)
-              $result.Context | Format-List
+              $result.Context | Format-List | Out-String
               $result.Context.GetType().Name
               if ($result.GitConfig -isnot [String]) {
                   throw "GitConfig is not a PSCustomObject"
               }
 
-              $result.GitConfig | Format-List
+              $result.GitConfig | Format-List | Out-String
               $result.GitConfig.GetType().Name
               if ($result.GitConfig -isnot [String]) {
                   throw "GitConfig is a PSCustomObject"
@@ -348,7 +349,8 @@ jobs:
         env:
           Item: ${{ steps.test.outputs.item }}
         run: |
-          $env:Item
+          $PSStyle.OutputRendering = 'Ansi'
+          $env:Item | Format-Table | Out-String
           $env:Item | ConvertFrom-Json
 
           if (-not (Test-Json -Json $env:Item)) {
@@ -387,8 +389,9 @@ jobs:
           Token: ${{ secrets.TEST_USER_PAT }}
           Prerelease: ${{ inputs.Prerelease }}
           Script: |
+            $PSStyle.OutputRendering = 'Ansi'
             LogGroup 'Get-GitHubUser' {
-              Get-GitHubUser | Format-Table -AutoSize
+              Get-GitHubUser | Format-Table -AutoSize | Out-String
             }
 
   ActionTestWithUSERFGPAT:
@@ -405,8 +408,9 @@ jobs:
           Token: ${{ secrets.TEST_USER_USER_FG_PAT }}
           Prerelease: ${{ inputs.Prerelease }}
           Script: |
+            $PSStyle.OutputRendering = 'Ansi'
             LogGroup 'Get-GitHubUser' {
-              Get-GitHubUser | Format-Table -AutoSize
+              Get-GitHubUser | Format-Table -AutoSize | Out-String
             }
 
   ActionTestWithORGFGPAT:
@@ -423,8 +427,9 @@ jobs:
           Token: ${{ secrets.TEST_USER_ORG_FG_PAT }}
           Prerelease: ${{ inputs.Prerelease }}
           Script: |
+            $PSStyle.OutputRendering = 'Ansi'
             LogGroup 'Get-GitHubUser' {
-              Get-GitHubUser | Format-Table -AutoSize
+              Get-GitHubUser | Format-Table -AutoSize | Out-String
             }
 
   ActionTestWithGitHubAppEnt:
@@ -442,19 +447,20 @@ jobs:
           PrivateKey: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
           Prerelease: ${{ inputs.Prerelease }}
           Script: |
+            $PSStyle.OutputRendering = 'Ansi'
             LogGroup 'Get-GitHubApp' {
-              Get-GitHubApp | Format-Table -AutoSize
+              Get-GitHubApp | Format-Table -AutoSize | Out-String
             }
 
             LogGroup 'Get-GitHubAppInstallation' {
-              Get-GitHubAppInstallation | Format-Table -AutoSize
+              Get-GitHubAppInstallation | Format-Table -AutoSize | Out-String
             }
 
             LogGroup 'Do something as an installation' {
               Get-GithubAppInstallation | New-GitHubAppInstallationAccessToken | ForEach-Object {
                 Connect-GitHub -Token $_.token -Silent
-                Get-GitHubContext | Format-Table -AutoSize
-                Get-GitHubGitConfig | Format-Table -AutoSize
+                Get-GitHubContext | Format-Table -AutoSize | Out-String
+                Get-GitHubGitConfig | Format-Table -AutoSize | Out-String
               }
             }
 
@@ -474,17 +480,17 @@ jobs:
           Prerelease: ${{ inputs.Prerelease }}
           Script: |
             LogGroup 'Get-GitHubApp' {
-              Get-GitHubApp | Format-Table -AutoSize
+              Get-GitHubApp | Format-Table -AutoSize | Out-String
             }
 
             LogGroup 'Get-GitHubAppInstallation' {
-              Get-GitHubAppInstallation | Format-Table -AutoSize
+              Get-GitHubAppInstallation | Format-Table -AutoSize | Out-String
             }
 
             LogGroup 'Do something as an installation' {
               Get-GithubAppInstallation | New-GitHubAppInstallationAccessToken | ForEach-Object {
                 Connect-GitHub -Token $_.token -Silent
-                Get-GitHubContext | Format-Table -AutoSize
-                Get-GitHubGitConfig | Format-Table -AutoSize
+                Get-GitHubContext | Format-Table -AutoSize | Out-String
+                Get-GitHubGitConfig | Format-Table -AutoSize | Out-String
               }
             }

--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -216,7 +216,6 @@ jobs:
                 Get-Content $env:GITHUB_OUTPUT -Raw | Set-GitHubStepSummary
             }
 
-
       - name: Run-test
         shell: pwsh
         env:

--- a/scripts/info.ps1
+++ b/scripts/info.ps1
@@ -6,6 +6,7 @@ param()
 begin {
     $scriptName = $MyInvocation.MyCommand.Name
     Write-Debug "[$scriptName] - Start"
+    $PSStyle.OutputRendering = 'Ansi'
 }
 
 process {
@@ -21,12 +22,12 @@ process {
         Write-Output $fenceStart
 
         LogGroup ' - Installed modules' {
-            Get-InstalledPSResource | Select-Object Name, Version, Prerelease | Sort-Object -Property Name | Format-Table -AutoSize
+            Get-InstalledPSResource | Select-Object Name, Version, Prerelease | Sort-Object -Property Name | Format-Table -AutoSize | Out-String
         }
 
         LogGroup ' - GitHub connection - Default' {
             $context = Get-GitHubContext
-            $context | Format-List
+            $context | Format-List | Out-String
 
             Write-Verbose "Token?    [$([string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token))]"
             Write-Verbose "AuthType? [$($context.AuthType)] - [$($context.AuthType -ne 'APP')]"
@@ -44,11 +45,11 @@ process {
         }
 
         LogGroup ' - GitHub connection - List' {
-            Get-GitHubContext -ListAvailable | Format-Table
+            Get-GitHubContext -ListAvailable | Format-Table | Out-String
         }
 
         LogGroup ' - Configuration' {
-            Get-GitHubConfig | Format-List
+            Get-GitHubConfig | Format-List | Out-String
         }
 
         $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'

--- a/scripts/info.ps1
+++ b/scripts/info.ps1
@@ -6,7 +6,6 @@ param()
 begin {
     $scriptName = $MyInvocation.MyCommand.Name
     Write-Debug "[$scriptName] - Start"
-    $PSStyle.OutputRendering = 'Ansi'
 }
 
 process {

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -4,6 +4,7 @@ param()
 begin {
     $scriptName = $MyInvocation.MyCommand.Name
     Write-Debug "[$scriptName] - Start"
+    $PSStyle.OutputRendering = 'Ansi'
 }
 
 process {
@@ -35,7 +36,7 @@ process {
 
         if ($showInit) {
             Write-Output 'Already installed:'
-            $alreadyInstalled | Format-List
+            $alreadyInstalled | Format-List | Out-String
         }
         if (-not $alreadyInstalled) {
             $params = @{
@@ -66,7 +67,7 @@ process {
         $alreadyImported = Get-Module -Name $Name
         if ($showInit) {
             Write-Output 'Already imported:'
-            $alreadyImported | Format-List
+            $alreadyImported | Format-List | Out-String
         }
         if (-not $alreadyImported) {
             Write-Verbose "Importing module: $Name"
@@ -88,7 +89,7 @@ process {
         }
         if ($showInit) {
             Write-Output 'Module status:'
-            $moduleStatus | Format-List
+            $moduleStatus | Format-List | Out-String
             Write-Output '::endgroup::'
             Write-Output '::group:: - Connect to GitHub'
         }

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -7,7 +7,6 @@ $DebugPreference = 'SilentlyContinue'
 $VerbosePreference = 'SilentlyContinue'
 $scriptName = $MyInvocation.MyCommand.Name
 Write-Debug "[$scriptName] - Start"
-$PSStyle.OutputRendering = 'Ansi'
 
 try {
     $fenceTitle = 'GitHub-Script'

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -35,9 +35,9 @@ try {
         $blue = $PSStyle.Foreground.Blue
         $reset = $PSStyle.Reset
         LogGroup " - $blue$($output.Name)$reset" {
-            $output = "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
+            $outputAccess = "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
             $outputFence = ('─' * ($output.Length - 1))
-            Write-Output $output
+            Write-Output $outputAccess
             Write-Output $outputFence
             $output.Value | Format-List | Out-String
         }

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -36,7 +36,7 @@ try {
         $reset = $PSStyle.Reset
         LogGroup " - $blue$($output.Name)$reset" {
             $outputAccess = "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
-            $outputFence = ('─' * ($output.Length - 9))
+            $outputFence = ('─' * ($outputAccess.Length - 9))
             Write-Output $outputAccess
             Write-Output $outputFence
             $output.Value | Format-List | Out-String

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -34,7 +34,7 @@ try {
     foreach ($output in $result.PSObject.Properties) {
         $blue = $PSStyle.Foreground.Blue
         $reset = $PSStyle.Reset
-        LogGroup " - Output: $blue$($output.Name)$reset" {
+        LogGroup " - $blue$($output.Name)$reset" {
             Write-Output "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
             $output.Value | Format-List | Out-String
         }

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -33,7 +33,11 @@ try {
             Write-Warning "File not found: $env:GITHUB_OUTPUT"
         }
 
-        $result | Format-List | Out-String
+        foreach ($output in $result.PSObject.Properties) {
+            LogGroup " - Outputs - $($output.Name)" {
+                $output.Value | Format-List | Out-String
+            }
+        }
         Write-Output "Access outputs using `${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).<output-name> }}"
     }
     $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -33,7 +33,7 @@ try {
             Write-Warning "File not found: $env:GITHUB_OUTPUT"
         }
 
-        $result | Format-List
+        $result | Format-List | Out-String
         Write-Output "Access outputs using `${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).<output-name> }}"
     }
     $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -34,9 +34,10 @@ try {
     foreach ($output in $result.PSObject.Properties) {
         $blue = $PSStyle.Foreground.Blue
         $reset = $PSStyle.Reset
-        $outputFence = ('-' * ($fenceStart.Length - 1))
         LogGroup " - $blue$($output.Name)$reset" {
-            Write-Output "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
+            $output = "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
+            $outputFence = ('-' * ($output.Length - 1))
+            Write-Output $output
             Write-Output $outputFence
             $output.Value | Format-List | Out-String
         }

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -34,7 +34,9 @@ try {
 
     foreach ($output in $result.PSObject.Properties) {
         LogGroup " - Outputs - $($output.Name)" {
-            Write-Output "Accessible via: [`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}]"
+            $blue = $PSStyle.Foreground.BrightCyan
+            $reset = $PSStyle.Reset
+            Write-Output "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
             $output.Value | Format-List | Out-String
         }
     }

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -32,9 +32,9 @@ try {
     }
 
     foreach ($output in $result.PSObject.Properties) {
-        LogGroup " - Outputs - $($output.Name)" {
-            $blue = $PSStyle.Foreground.Blue
-            $reset = $PSStyle.Reset
+        $blue = $PSStyle.Foreground.Blue
+        $reset = $PSStyle.Reset
+        LogGroup " - Output: $blue$($output.Name)$reset" {
             Write-Output "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
             $output.Value | Format-List | Out-String
         }

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -36,7 +36,7 @@ try {
         $reset = $PSStyle.Reset
         LogGroup " - $blue$($output.Name)$reset" {
             $outputAccess = "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
-            $outputFence = ('─' * ($output.Length - 1))
+            $outputFence = ('─' * ($output.Length - 9))
             Write-Output $outputAccess
             Write-Output $outputFence
             $output.Value | Format-List | Out-String

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -34,7 +34,7 @@ try {
 
     foreach ($output in $result.PSObject.Properties) {
         LogGroup " - Outputs - $($output.Name)" {
-            $blue = $PSStyle.Foreground.BrightCyan
+            $blue = $PSStyle.Foreground.Blue
             $reset = $PSStyle.Reset
             Write-Output "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
             $output.Value | Format-List | Out-String

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -7,6 +7,7 @@ $DebugPreference = 'SilentlyContinue'
 $VerbosePreference = 'SilentlyContinue'
 $scriptName = $MyInvocation.MyCommand.Name
 Write-Debug "[$scriptName] - Start"
+$PSStyle.OutputRendering = 'Ansi'
 
 try {
     $fenceTitle = 'GitHub-Script'

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -24,20 +24,18 @@ try {
     }
     $fenceStart = "┏━━┫ $fenceTitle - Outputs ┣━━━━━┓"
     Write-Output $fenceStart
-    LogGroup ' - Outputs' {
-        if ([string]::IsNullOrEmpty($env:GITHUB_ACTION)) {
-            Write-GitHubWarning 'Outputs cannot be accessed as the step has no ID.'
-        }
+    if ([string]::IsNullOrEmpty($env:GITHUB_ACTION)) {
+        Write-GitHubWarning 'Outputs cannot be accessed as the step has no ID.'
+    }
 
-        if (-not (Test-Path -Path $env:GITHUB_OUTPUT)) {
-            Write-Warning "File not found: $env:GITHUB_OUTPUT"
-        }
+    if (-not (Test-Path -Path $env:GITHUB_OUTPUT)) {
+        Write-Warning "File not found: $env:GITHUB_OUTPUT"
+    }
 
-        foreach ($output in $result.PSObject.Properties) {
-            LogGroup " - Outputs - $($output.Name)" {
-                Write-Output "`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}"
-                $output.Value | Format-List | Out-String
-            }
+    foreach ($output in $result.PSObject.Properties) {
+        LogGroup " - Outputs - $($output.Name)" {
+            Write-Output "Accessible via: [`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}]"
+            $output.Value | Format-List | Out-String
         }
     }
     $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -36,7 +36,7 @@ try {
         $reset = $PSStyle.Reset
         LogGroup " - $blue$($output.Name)$reset" {
             $output = "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
-            $outputFence = ('-' * ($output.Length - 1))
+            $outputFence = ('─' * ($output.Length - 1))
             Write-Output $output
             Write-Output $outputFence
             $output.Value | Format-List | Out-String

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -34,8 +34,10 @@ try {
     foreach ($output in $result.PSObject.Properties) {
         $blue = $PSStyle.Foreground.Blue
         $reset = $PSStyle.Reset
+        $outputFence = ('-' * ($fenceStart.Length - 1))
         LogGroup " - $blue$($output.Name)$reset" {
             Write-Output "Accessible via: [$blue`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}$reset]"
+            Write-Output $outputFence
             $output.Value | Format-List | Out-String
         }
     }

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -35,10 +35,10 @@ try {
 
         foreach ($output in $result.PSObject.Properties) {
             LogGroup " - Outputs - $($output.Name)" {
+                Write-Output "`${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).$($output.Name) }}"
                 $output.Value | Format-List | Out-String
             }
         }
-        Write-Output "Access outputs using `${{ fromJson(steps.$env:GITHUB_ACTION.outputs.result).<output-name> }}"
     }
     $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'
     Write-Output $fenceEnd

--- a/tests/info.ps1
+++ b/tests/info.ps1
@@ -1,9 +1,9 @@
 ﻿#Requires -Modules GitHub
 
 LogGroup ' - Get-GithubEventData' {
-    Get-GitHubEventData | Format-List
+    Get-GitHubEventData | Format-List | Out-String
 }
 
 LogGroup ' - Get-GithubRunnerData' {
-    Get-GitHubRunnerData | Format-List
+    Get-GitHubRunnerData | Format-List | Out-String
 }


### PR DESCRIPTION
## Description

This pull request includes changes to improve output formatting and enable ANSI output rendering, including adding `Out-String` to several `Format-*` cmdlets and setting `OutputRendering` to 'Ansi'. This is to avoid table and list output to wrap or cut of text.

### Improvements to output formatting:

* `scripts/info.ps1`:
  * Added `Out-String` to the output of `Format-Table` and `Format-List` cmdlets.
* `scripts/init.ps1`:
  * Added `Out-String` to the output of `Format-List` cmdlets.
  * Set `$PSStyle.OutputRendering` to 'Ansi' to enable ANSI output rendering.
* `tests/info.ps1`:
  * Added `Out-String` to the output of `Format-List` cmdlets.

### Enabling ANSI output rendering:

* `scripts/outputs.ps1`:
  * Modified the script to use `Out-String` for output formatting and added a loop to log each output property with ANSI color styling.

### Tests
* `.github/workflows/TestWorkflow.yml`:
  * Enabled ANSI output rendering and used `Out-String` to format various outputs in multiple sections, including `Result - Json`, `Result - Object`, `Context`, `GitConfig`, `WISECAT`, and `Get-GitHubUser`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
