### PR TITLE
🩹 [Patch]: Update default values for WorkingDirectory to be '.'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ To get started with your own GitHub PowerShell based action, [create a new repos
 
 ### Inputs
 
-| Name               | Description                                                               | Required | Default                   |
-|--------------------|---------------------------------------------------------------------------|----------|---------------------------|
-| `Script`           | The script to run. Can be inline, multi-line, or a path to a script file. | false    |                           |
-| `Token`            | Log in using an Installation Access Token (IAT).                          | false    | `${{ github.token }}`     |
-| `ClientID`         | Log in using a GitHub App, with the App's Client ID and Private Key.      | false    |                           |
-| `PrivateKey`       | Log in using a GitHub App, with the App's Client ID and Private Key.      | false    |                           |
-| `Debug`            | Enable debug output.                                                      | false    | `'false'`                 |
-| `Verbose`          | Enable verbose output.                                                    | false    | `'false'`                 |
-| `Version`          | Specifies the exact version of the GitHub module to install.              | false    |                           |
-| `Prerelease`       | Allow prerelease versions if available.                                   | false    | `'false'`                 |
-| `ShowInfo`         | Show information about the environment.                                   | false    | `'true'`                  |
-| `ShowInit`         | Show information about the initialization.                                | false    | `'false'`                 |
-| `ShowOutput`       | Show the script's output.                                                 | false    | `'false'`                 |
-| `WorkingDirectory` | The working directory where the script runs.                              | false    | `${{ github.workspace }}` |
+| Name               | Description                                                               | Required | Default               |
+|--------------------|---------------------------------------------------------------------------|----------|-----------------------|
+| `Script`           | The script to run. Can be inline, multi-line, or a path to a script file. | false    |                       |
+| `Token`            | Log in using an Installation Access Token (IAT).                          | false    | `${{ github.token }}` |
+| `ClientID`         | Log in using a GitHub App, with the App's Client ID and Private Key.      | false    |                       |
+| `PrivateKey`       | Log in using a GitHub App, with the App's Client ID and Private Key.      | false    |                       |
+| `Debug`            | Enable debug output.                                                      | false    | `'false'`             |
+| `Verbose`          | Enable verbose output.                                                    | false    | `'false'`             |
+| `Version`          | Specifies the exact version of the GitHub module to install.              | false    |                       |
+| `Prerelease`       | Allow prerelease versions if available.                                   | false    | `'false'`             |
+| `ShowInfo`         | Show information about the environment.                                   | false    | `'true'`              |
+| `ShowInit`         | Show information about the initialization.                                | false    | `'false'`             |
+| `ShowOutput`       | Show the script's output.                                                 | false    | `'false'`             |
+| `WorkingDirectory` | The working directory where the script runs.                              | false    | `'.'`                 |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -49,7 +49,7 @@ inputs:
   WorkingDirectory:
     description: The working directory where the script will run from.
     required: false
-    default: ${{ github.workspace }}
+    default: '.'
 
 outputs:
   result:


### PR DESCRIPTION
## Description

This pull request includes updates to the default values for the `WorkingDirectory` input in both the `README.md` and `action.yml` files. These changes ensure consistency in the default working directory for the script.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L24-R24): Updated the default value for the `WorkingDirectory` input from `${{ github.workspace }}` to `'.'`.

Configuration updates:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L52-R52): Updated the default value for the `WorkingDirectory` input from `${{ github.workspace }}` to `'.'`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
