### PR TITLE
🩹 [Patch]: Enable reinstall of modules to ensure the correct version of `GitHub` is installed

### DIFF
--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -44,6 +44,8 @@ process {
                 Repository      = 'PSGallery'
                 TrustRepository = $true
                 Prerelease      = $Prerelease
+                Reinstall       = $true
+                WarningAction   = 'SilentlyContinue'
             }
             if ($Version) {
                 $params['Version'] = $Version


### PR DESCRIPTION
## Description

This pull request includes a small change to the `scripts/init.ps1` file. The change adds two new parameters, `Reinstall` and `WarningAction`, to the process block to ensure that the module is reinstalled and warnings are suppressed.

- Fixes #40 

Changes in `process {` in file `scripts/init.ps1`:

* Added `Reinstall` parameter set to `true`.
* Added `WarningAction` parameter set to `'SilentlyContinue'`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
