### PR TITLE
🚀 [Feature]: Configure PowerShell ErrorView settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To get started with your own GitHub PowerShell based action, [create a new repos
 | `Verbose`          | Enable verbose output.                                                    | false    | `'false'`             |
 | `Version`          | Specifies the exact version of the GitHub module to install.              | false    |                       |
 | `Prerelease`       | Allow prerelease versions if available.                                   | false    | `'false'`             |
+| `ErrorView`        | Configure the PowerShell `$ErrorView` variable. You can use full names ('NormalView', 'CategoryView', 'ConciseView', 'DetailedView'). It matches on partials. | false    | `'NormalView'`         |
 | `ShowInfo`         | Show information about the environment.                                   | false    | `'true'`              |
 | `ShowInit`         | Show information about the initialization.                                | false    | `'false'`             |
 | `ShowOutput`       | Show the script's output.                                                 | false    | `'false'`             |

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,10 @@ inputs:
     description: Show the output of the script.
     required: false
     default: 'false'
+  ErrorView:
+    description: Configure the PowerShell `$ErrorView` variable. You can use full names ('NormalView', 'CategoryView', 'ConciseView', 'DetailedView'). It matches on partials.
+    required: false
+    default: 'NormalView'
   WorkingDirectory:
     description: The working directory where the script will run from.
     required: false
@@ -79,6 +83,7 @@ runs:
         PSMODULE_GITHUB_SCRIPT_INPUT_ShowInfo: ${{ inputs.ShowInfo }}
         PSMODULE_GITHUB_SCRIPT_INPUT_ShowOutput: ${{ inputs.ShowOutput }}
         PSMODULE_GITHUB_SCRIPT_INPUT_Prerelease: ${{ inputs.Prerelease }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView: ${{ inputs.ErrorView }}
       run: |
         # ${{ inputs.Name }}
         try {

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -5,6 +5,22 @@ begin {
     $scriptName = $MyInvocation.MyCommand.Name
     Write-Debug "[$scriptName] - Start"
     $PSStyle.OutputRendering = 'Ansi'
+
+    # Configure ErrorView based on input parameter
+    if (-not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView)) {
+        $validViews = @('NormalView', 'CategoryView', 'ConciseView', 'DetailedView')
+        $errorViewSetting = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView
+
+        # Simply find the first validView that matches the input using wildcards
+        $matchedView = $validViews | Where-Object { $_ -like "*$errorViewSetting*" } | Select-Object -First 1
+
+        if ($matchedView) {
+            Write-Debug "[$scriptName] - Input [$errorViewSetting] matched with [$matchedView]"
+            $ErrorView = $matchedView
+        } else {
+            Write-Warning "[$scriptName] - Invalid ErrorView value: [$errorViewSetting]. Using default."
+        }
+    }
 }
 
 process {


### PR DESCRIPTION
## 🚀 New Feature: `ErrorView` Configuration

This release introduces a new feature to configure the PowerShell `$ErrorView` variable in the GitHub Action. This also sets the default to `NormalView` whereas the default in PowerShell is `ConciseView`. `NormalView` provides more information that would be great to get when troubleshooting errors in GitHub workflows. Users can still override this by adding their own settings in the provided script or using the input to set a different value when building actions or workflows.

#### Details

* Introduced the `ErrorView` input in `action.yml`, including its description, default value (`'NormalView'`), and marking it as optional.
* The input is mapped to the new environment variable `PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView` in the `action.yml` file.
* The environment variable is validated using wildcard matching against a predefined list of valid views, applies the matched view setting.
* Added a description for the new `ErrorView` option in the `README.md` file. This option allows users to configure the `$ErrorView` variable using full or partial names of valid views.
