### PR TITLE
🪲 [Fix]: Fix setting the `$ErrorView` setting via inputs

### DIFF
--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -225,8 +225,8 @@ jobs:
                 Get-Content $env:GITHUB_OUTPUT -Raw | Set-GitHubStepSummary
             }
 
-            LogGroup "ErrorView: $ErrorView" {
-                if ($errorView -ne 'NormalView') {
+            LogGroup "ErrorView should be 'NormalView' - [$ErrorView]" {
+                if ($ErrorView -ne 'NormalView') {
                     throw 'ErrorView is not NormalView'
                 }
             }

--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -225,6 +225,12 @@ jobs:
                 Get-Content $env:GITHUB_OUTPUT -Raw | Set-GitHubStepSummary
             }
 
+            LogGroup "ErrorView: $ErrorView" {
+                if ($errorView -ne 'NormalView') {
+                    throw 'ErrorView is not NormalView'
+                }
+            }
+
       - name: Run-test
         shell: pwsh
         env:

--- a/action.yml
+++ b/action.yml
@@ -91,6 +91,7 @@ runs:
         PSMODULE_GITHUB_SCRIPT_INPUT_PreserveCredentials: ${{ inputs.PreserveCredentials }}
       run: |
         # ${{ inputs.Name }}
+        $ErrorView = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView
         try {
           ${{ github.action_path }}/scripts/init.ps1
           ${{ github.action_path }}/scripts/info.ps1

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -8,7 +8,7 @@ begin {
 
     # Configure ErrorView based on input parameter
     LogGroup "Inputs:" {
-        Get-ChildItem env: | Where-Object { $_ -like 'PSMODULE_GITHUB_SCRIPT_INPUT_*' } | Out-String
+        Get-ChildItem env: | Where-Object { $_.Name -like 'PSMODULE_GITHUB_SCRIPT_INPUT_*' } | Out-String
     }
     if (-not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView)) {
         $validViews = @('NormalView', 'CategoryView', 'ConciseView', 'DetailedView')

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -7,6 +7,9 @@ begin {
     $PSStyle.OutputRendering = 'Ansi'
 
     # Configure ErrorView based on input parameter
+    LogGroup "Inputs:" {
+        Get-ChildItem env: | Where-Object { $_ -like 'PSMODULE_GITHUB_SCRIPT_INPUT_*' } | Out-String
+    }
     if (-not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView)) {
         $validViews = @('NormalView', 'CategoryView', 'ConciseView', 'DetailedView')
         $errorViewSetting = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -4,23 +4,6 @@ param()
 begin {
     $scriptName = $MyInvocation.MyCommand.Name
     Write-Debug "[$scriptName] - Start"
-    $PSStyle.OutputRendering = 'Ansi'
-
-    # Configure ErrorView based on input parameter
-    if (-not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView)) {
-        $validViews = @('NormalView', 'CategoryView', 'ConciseView', 'DetailedView')
-        $errorViewSetting = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView
-
-        # Simply find the first validView that matches the input using wildcards
-        $matchedView = $validViews | Where-Object { $_ -like "*$errorViewSetting*" } | Select-Object -First 1
-
-        if ($matchedView) {
-            Write-Debug "[$scriptName] - Input [$errorViewSetting] matched with [$matchedView]"
-            $ErrorView = $matchedView
-        } else {
-            Write-Warning "[$scriptName] - Invalid ErrorView value: [$errorViewSetting]. Using default."
-        }
-    }
 }
 
 process {

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -7,7 +7,6 @@ begin {
     $PSStyle.OutputRendering = 'Ansi'
 
     # Configure ErrorView based on input parameter
-    Get-ChildItem env: | Where-Object { $_.Name -like 'PSMODULE_GITHUB_SCRIPT_INPUT_*' } | Out-String
     if (-not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView)) {
         $validViews = @('NormalView', 'CategoryView', 'ConciseView', 'DetailedView')
         $errorViewSetting = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView

--- a/scripts/init.ps1
+++ b/scripts/init.ps1
@@ -7,9 +7,7 @@ begin {
     $PSStyle.OutputRendering = 'Ansi'
 
     # Configure ErrorView based on input parameter
-    LogGroup "Inputs:" {
-        Get-ChildItem env: | Where-Object { $_.Name -like 'PSMODULE_GITHUB_SCRIPT_INPUT_*' } | Out-String
-    }
+    Get-ChildItem env: | Where-Object { $_.Name -like 'PSMODULE_GITHUB_SCRIPT_INPUT_*' } | Out-String
     if (-not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView)) {
         $validViews = @('NormalView', 'CategoryView', 'ConciseView', 'DetailedView')
         $errorViewSetting = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView


### PR DESCRIPTION
This pull request introduces changes related to the handling of the `ErrorView` configuration in a GitHub Actions workflow. The changes streamline the `ErrorView` initialization logic by removing redundant code and adding validation to ensure `ErrorView` is set correctly during runtime.

### Changes to `ErrorView` handling:

* [`.github/workflows/TestWorkflow.yml`](diffhunk://#diff-242a265d6d6bfff6094c9285345022d0e6d7ddde58504dfc80249fafbd89ba2cR228-R233): Added a validation step to confirm that `ErrorView` is set to `'NormalView'` during the workflow execution. If not, an exception is thrown.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R94): Introduced the assignment of the `ErrorView` environment variable from the input parameter for use in subsequent scripts.
* [`scripts/init.ps1`](diffhunk://#diff-f47ceebe9ade2bb55cede031de8267e9c87b09336a93fcd557c02c1f488554b6L7-L23): Removed the redundant initialization and validation logic for `ErrorView`, as this is now handled directly in the workflow and action configuration.
