### PR TITLE
🪲 [Fix]: Fix debug and verbose inputs

### DIFF
--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -409,7 +409,7 @@ jobs:
           Prerelease: ${{ inputs.Prerelease }}
           Script: |
             LogGroup 'Get-GitHubUser' {
-              Get-GitHubUser | Format-Table -AutoSize | Out-String
+              Get-GitHubUser -Debug | Format-Table -AutoSize | Out-String
             }
 
             LogGroup 'Get-GitHubOrganization' {

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ To get started with your own GitHub PowerShell based action, [create a new repos
 | `Token`            | Log in using an Installation Access Token (IAT).                          | false    | `${{ github.token }}` |
 | `ClientID`         | Log in using a GitHub App, with the App's Client ID and Private Key.      | false    |                       |
 | `PrivateKey`       | Log in using a GitHub App, with the App's Client ID and Private Key.      | false    |                       |
-| `Debug`            | Enable debug output.                                                      | false    | `'false'`             |
-| `Verbose`          | Enable verbose output.                                                    | false    | `'false'`             |
+| `Debug`            | Enable debug output for the whole action.                                 | false    | `'false'`             |
+| `Verbose`          | Enable verbose output for the whole action.                               | false    | `'false'`             |
 | `Version`          | Specifies the exact version of the GitHub module to install.              | false    |                       |
 | `Prerelease`       | Allow prerelease versions if available.                                   | false    | `'false'`             |
 | `ErrorView`        | Configure the PowerShell `$ErrorView` variable. You can use full names ('NormalView', 'CategoryView', 'ConciseView', 'DetailedView'). It matches on partials. | false    | `'NormalView'`         |

--- a/action.yml
+++ b/action.yml
@@ -92,6 +92,8 @@ runs:
       run: |
         # ${{ inputs.Name }}
         $ErrorView = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView
+        $DebugPreference = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Debug -eq 'true' ? 'Continue' : 'SilentlyContinue'
+        $VerbosePreference = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Verbose -eq 'true' ? 'Continue' : 'SilentlyContinue'
         try {
           ${{ github.action_path }}/scripts/init.ps1
           ${{ github.action_path }}/scripts/info.ps1

--- a/action.yml
+++ b/action.yml
@@ -24,11 +24,11 @@ inputs:
     description: Log in using a GitHub App, using the App's Client ID and Private Key.
     required: false
   Debug:
-    description: Enable debug output.
+    description: Enable debug output for the whole action.
     required: false
     default: 'false'
   Verbose:
-    description: Enable verbose output.
+    description: Enable verbose output for the whole action.
     required: false
     default: 'false'
   Version:

--- a/scripts/info.ps1
+++ b/scripts/info.ps1
@@ -60,6 +60,4 @@ process {
 
 end {
     Write-Debug "[$scriptName] - End"
-    $DebugPreference = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Debug -eq 'true' ? 'Continue' : 'SilentlyContinue'
-    $VerbosePreference = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Verbose -eq 'true' ? 'Continue' : 'SilentlyContinue'
 }

--- a/scripts/outputs.ps1
+++ b/scripts/outputs.ps1
@@ -3,8 +3,6 @@
 [CmdletBinding()]
 param()
 
-$DebugPreference = 'SilentlyContinue'
-$VerbosePreference = 'SilentlyContinue'
 $scriptName = $MyInvocation.MyCommand.Name
 Write-Debug "[$scriptName] - Start"
 


### PR DESCRIPTION
This pull request introduces updates to improve debug and verbose output handling across the GitHub PowerShell-based action. The changes ensure consistent configuration of debug and verbose preferences and enhance clarity in documentation and workflow files.

### Debug and Verbose Output Handling Updates:
* [`.github/workflows/TestWorkflow.yml`](diffhunk://#diff-242a265d6d6bfff6094c9285345022d0e6d7ddde58504dfc80249fafbd89ba2cL412-R412): Added the `-Debug` parameter to the `Get-GitHubUser` command to enable debug output during the workflow execution.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L27-R31): Updated the descriptions for `Debug` and `Verbose` inputs to clarify that they enable debug and verbose output for the entire action. Additionally, configured `$DebugPreference` and `$VerbosePreference` based on input values to set PowerShell preferences dynamically. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L27-R31) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R95-R96)
* [`scripts/info.ps1`](diffhunk://#diff-82c586f67d16e32953b47a962c269d0a484f8aa660d71ad354e91fd2d4334cd9L63-L64): Removed redundant `$DebugPreference` and `$VerbosePreference` configuration from the `end` block, as these preferences are now set globally in the action runner.
* [`scripts/outputs.ps1`](diffhunk://#diff-ee715ca93229232e95883bf00629fd14e3bf174cdc17b723c4cc5d70e6a60a58L6-L7): Removed hardcoded `$DebugPreference` and `$VerbosePreference` settings to align with the new dynamic configuration approach.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L18-R19): Improved descriptions for `Debug` and `Verbose` inputs to specify that they enable output for the entire action, enhancing clarity for users.