### PR TITLE
🩹 [Patch]: Add logging for GitHub event data in info script

### DIFF
--- a/scripts/info.ps1
+++ b/scripts/info.ps1
@@ -51,6 +51,10 @@ process {
             Get-GitHubConfig | Format-List | Out-String
         }
 
+        LogGroup ' - Event Information' {
+            Get-GitHubEventData | Format-List | Out-String
+        }
+
         $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'
         Write-Output $fenceEnd
     } catch {


### PR DESCRIPTION
## Description

This pull request adds a new logging group to the `scripts/info.ps1` file for better visibility into event-related information.

### Logging Improvements:
* [`scripts/info.ps1`](diffhunk://#diff-82c586f67d16e32953b47a962c269d0a484f8aa660d71ad354e91fd2d4334cd9R54-R57): Added a new log group labeled 'Event Information' that retrieves and formats GitHub event data using `Get-GitHubEventData`.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
