### PR TITLE
🚀 [Minor]: GitHub API rate limit details now available in action logs

### DIFF
--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -71,6 +71,7 @@ jobs:
           Debug: true
           Verbose: true
           ShowInit: true
+          ShowRateLimit: true
 
   ActionTestWithScript:
     name: WithScript
@@ -96,6 +97,7 @@ jobs:
         with:
           Script: tests/info.ps1
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
 
       - name: Action-Test [.\tests\info.ps1]
         if: success() || failure()
@@ -103,6 +105,7 @@ jobs:
         with:
           Script: .\tests\info.ps1
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
 
       - name: Action-Test [./tests/info.ps1]
         if: success() || failure()
@@ -110,6 +113,7 @@ jobs:
         with:
           Script: ./tests/info.ps1
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
 
       - name: Action-Test [. .\tests\info.ps1]
         if: success() || failure()
@@ -117,6 +121,7 @@ jobs:
         with:
           Script: . .\tests\info.ps1
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
 
       - name: Action-Test [. ./tests/info.ps1]
         if: success() || failure()
@@ -124,6 +129,7 @@ jobs:
         with:
           Script: . ./tests/info.ps1
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
 
       - name: Action-Test [. '.\tests\info.ps1']
         if: success() || failure()
@@ -131,6 +137,7 @@ jobs:
         with:
           Script: . '.\tests\info.ps1'
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
 
       - name: Action-Test [. './tests/info.ps1']
         if: success() || failure()
@@ -138,6 +145,7 @@ jobs:
         with:
           Script: . './tests/info.ps1'
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
 
   ActionTestCommands:
     name: Commands + Outputs
@@ -160,6 +168,7 @@ jobs:
           Prerelease: ${{ inputs.Prerelease }}
           ShowInit: true
           ShowOutput: true
+          ShowRateLimit: true
           Script: |
             LogGroup 'Get-GitHubZen' {
               $cat = Get-GitHubOctocat
@@ -340,6 +349,7 @@ jobs:
           Prerelease: true
           ShowInit: true
           ShowOutput: true
+          ShowRateLimit: true
           Script: |
             LogGroup 'MatrixTest' {
                 $matrixTest = @{
@@ -447,6 +457,7 @@ jobs:
         with:
           Token: ${{ secrets.TEST_USER_USER_FG_PAT }}
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
           Script: |
             LogGroup 'Get-GitHubUser' {
               Get-GitHubUser | Format-Table -AutoSize | Out-String
@@ -474,6 +485,7 @@ jobs:
         with:
           Token: ${{ secrets.TEST_USER_ORG_FG_PAT }}
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
           Script: |
             LogGroup 'Get-GitHubUser' {
               Get-GitHubUser | Format-Table -AutoSize | Out-String
@@ -502,6 +514,7 @@ jobs:
           ClientID: ${{ secrets.TEST_APP_ENT_CLIENT_ID }}
           PrivateKey: ${{ secrets.TEST_APP_ENT_PRIVATE_KEY }}
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
           Script: |
             LogGroup 'Get-GitHubApp' {
               Get-GitHubApp | Format-List | Out-String
@@ -585,6 +598,7 @@ jobs:
           ClientID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
           KeyVaultKeyReference: 'https://psmodule-test-vault.vault.azure.net/keys/psmodule-org-app/569ae34250e64adca6a2b2d159d454a5'
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
           Script: |
             LogGroup 'Context details' {
                 Get-GitHubContext | Select-Object * | Out-String
@@ -635,6 +649,7 @@ jobs:
           ClientID: ${{ secrets.TEST_APP_ORG_CLIENT_ID }}
           KeyVaultKeyReference: 'https://psmodule-test-vault.vault.azure.net/keys/psmodule-org-app/'
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
           Script: |
             LogGroup 'Context details' {
                 Get-GitHubContext | Select-Object * | Out-String
@@ -675,6 +690,7 @@ jobs:
           Token: ${{ secrets.TEST_USER_PAT }}
           PreserveCredentials: false
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
           Script: |
             LogGroup 'Get-GitHubUser with credentials that will be cleaned up' {
               Get-GitHubUser | Format-Table -AutoSize | Out-String

--- a/.github/workflows/TestWorkflow.yml
+++ b/.github/workflows/TestWorkflow.yml
@@ -62,6 +62,7 @@ jobs:
           Prerelease: ${{ inputs.Prerelease }}
           Debug: true
           Verbose: true
+          ShowRateLimit: true
 
       - name: Action-Test [ShowInit]
         uses: ./
@@ -398,6 +399,7 @@ jobs:
         with:
           Token: ''
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
           Script: |
             LogGroup 'My group' {
               'This is a group'
@@ -417,6 +419,7 @@ jobs:
         with:
           Token: ${{ secrets.TEST_USER_PAT }}
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
           Script: |
             LogGroup 'Get-GitHubUser' {
               Get-GitHubUser -Debug | Format-Table -AutoSize | Out-String
@@ -535,6 +538,7 @@ jobs:
           ClientID: '${{ secrets.TEST_APP_ORG_CLIENT_ID }}'      # Test with quotes on input
           PrivateKey: '${{ secrets.TEST_APP_ORG_PRIVATE_KEY }}'  # Test with quotes on input
           Prerelease: ${{ inputs.Prerelease }}
+          ShowRateLimit: true
           Script: |
             LogGroup 'Get-GitHubApp' {
               Get-GitHubApp | Format-List | Out-String

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Runs a script with `PreserveCredentials` set to `false` to automatically disconn
 
 #### Example 8: Show GitHub API rate limit usage
 
-Displays the GitHub API rate limit status before and after the script runs. The **Rate Limits** log group shows `Limit`, `Used`, `Remaining`, `ResetsAt`, and `ResetsIn` for every resource category (core, search, graphql, etc.), making it easy to see exactly how many API calls a workflow step consumed.
+Displays the GitHub API rate limit status before and after the script runs. The **Rate Limits** log group shows `Limit`, `Used`, `Remaining`, `ResetsAt`, and `ResetsIn` for every resource category (core, search, GraphQL, etc.), making it easy to see exactly how many API calls a workflow step consumed.
 
 ```yaml
 - name: Run script with rate limit visibility

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Runs a script with `PreserveCredentials` set to `false` to automatically disconn
 
 #### Example 8: Show GitHub API rate limit usage
 
-Displays the GitHub API rate limit status before and after the script runs. The **Rate Limits** log group shows `Limit`, `Used`, `Remaining`, `ResetsAt`, and `ResetsIn` for every resource category (core, search, GraphQL, etc.), making it easy to see exactly how many API calls a workflow step consumed.
+Displays the GitHub API rate limit status before and after the script runs. The **Rate Limits** log group shows `Limit`, `Used`, `Remaining`, `ResetsAt`, and `ResetsIn` for every resource category (`core`, `search`, `graphql`, etc.), making it easy to see exactly how many API calls a workflow step consumed.
 
 ```yaml
 - name: Run script with rate limit visibility

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ To get started with your own GitHub PowerShell based action, [create a new repos
 | `ShowInfo`             | Show information about the environment.                                                                                                                       | false    | `'true'`              |
 | `ShowInit`             | Show information about the initialization.                                                                                                                    | false    | `'false'`             |
 | `ShowOutput`           | Show the script's output.                                                                                                                                     | false    | `'false'`             |
+| `ShowRateLimit`        | Show GitHub API rate limit information before and after script execution.                                                                                     | false    | `'false'`             |
 | `WorkingDirectory`     | The working directory where the script runs.                                                                                                                  | false    | `'.'`                 |
 | `PreserveCredentials`  | Preserve credentials after script execution. If false, disconnects GitHub contexts and CLI using Disconnect-GitHubAccount.                                    | false    | `'true'`              |
 
@@ -242,4 +243,17 @@ Runs a script with `PreserveCredentials` set to `false` to automatically disconn
     Script: |
       Get-GitHubUser
       # Credentials will be disconnected after this step
+```
+
+#### Example 8: Show GitHub API rate limit usage
+
+Displays the GitHub API rate limit status before and after the script runs. The **Rate Limits** log group shows `Limit`, `Used`, `Remaining`, `ResetsAt`, and `ResetsIn` for every resource category (core, search, graphql, etc.), making it easy to see exactly how many API calls a workflow step consumed.
+
+```yaml
+- name: Run script with rate limit visibility
+  uses: PSModule/GitHub-Script@v1
+  with:
+    ShowRateLimit: 'true'
+    Script: |
+      Get-GitHubRepository -Owner PSModule -Name GitHub-Script
 ```

--- a/action.yml
+++ b/action.yml
@@ -106,12 +106,8 @@ runs:
         try {
           ${{ github.action_path }}/src/init.ps1
           ${{ github.action_path }}/src/info.ps1
-          $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL = 'Pre'
-          ${{ github.action_path }}/src/ratelimit.ps1
           ${{ inputs.Script }}
           ${{ github.action_path }}/src/outputs.ps1
-          $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL = 'Post'
-          ${{ github.action_path }}/src/ratelimit.ps1
         }
         finally {
           ${{ github.action_path }}/src/clean.ps1

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,10 @@ inputs:
     description: Show the output of the script.
     required: false
     default: 'false'
+  ShowRateLimit:
+    description: Show GitHub API rate limit information before and after script execution.
+    required: false
+    default: 'false'
   ErrorView:
     description: Configure the PowerShell `$ErrorView` variable. You can use full names ('NormalView', 'CategoryView', 'ConciseView', 'DetailedView'). It matches on partials.
     required: false
@@ -91,6 +95,7 @@ runs:
         PSMODULE_GITHUB_SCRIPT_INPUT_ShowInfo: ${{ inputs.ShowInfo }}
         PSMODULE_GITHUB_SCRIPT_INPUT_ShowOutput: ${{ inputs.ShowOutput }}
         PSMODULE_GITHUB_SCRIPT_INPUT_Prerelease: ${{ inputs.Prerelease }}
+        PSMODULE_GITHUB_SCRIPT_INPUT_ShowRateLimit: ${{ inputs.ShowRateLimit }}
         PSMODULE_GITHUB_SCRIPT_INPUT_ErrorView: ${{ inputs.ErrorView }}
         PSMODULE_GITHUB_SCRIPT_INPUT_PreserveCredentials: ${{ inputs.PreserveCredentials }}
       run: |
@@ -101,8 +106,12 @@ runs:
         try {
           ${{ github.action_path }}/src/init.ps1
           ${{ github.action_path }}/src/info.ps1
+          $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL = 'Pre'
+          ${{ github.action_path }}/src/ratelimit.ps1
           ${{ inputs.Script }}
           ${{ github.action_path }}/src/outputs.ps1
+          $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL = 'Post'
+          ${{ github.action_path }}/src/ratelimit.ps1
         }
         finally {
           ${{ github.action_path }}/src/clean.ps1

--- a/src/info.ps1
+++ b/src/info.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules GitHub
+#Requires -Modules GitHub
 
 [CmdletBinding()]
 param()
@@ -12,14 +12,19 @@ process {
     try {
         $fenceTitle = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Name
 
-        Write-Debug "[$scriptName] - ShowInfo: $env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowInfo"
-        if ($env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowInfo -ne 'true') {
+        $showInfo = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowInfo -eq 'true'
+        $showRateLimit = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowRateLimit -eq 'true'
+
+        Write-Debug "[$scriptName] - ShowInfo: $showInfo"
+        Write-Debug "[$scriptName] - ShowRateLimit: $showRateLimit"
+        if (-not $showInfo -and -not $showRateLimit) {
             return
         }
 
         $fenceStart = "┏━━┫ $fenceTitle - Info ┣━━━━━━━━┓"
         Write-Output $fenceStart
 
+        if ($showInfo) {
         LogGroup ' - Installed modules' {
             Get-InstalledPSResource | Select-Object Name, Version, Prerelease | Sort-Object -Property Name | Format-Table -AutoSize | Out-String
         }
@@ -54,6 +59,10 @@ process {
         LogGroup ' - Event Information' {
             Get-GitHubEventData | Format-List | Out-String
         }
+        } # end if ($showInfo)
+
+        $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL = 'Pre'
+        & "$PSScriptRoot/ratelimit.ps1"
 
         $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'
         Write-Output $fenceEnd

--- a/src/info.ps1
+++ b/src/info.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules GitHub
+﻿#Requires -Modules GitHub
 
 [CmdletBinding()]
 param()
@@ -25,40 +25,40 @@ process {
         Write-Output $fenceStart
 
         if ($showInfo) {
-        LogGroup ' - Installed modules' {
-            Get-InstalledPSResource | Select-Object Name, Version, Prerelease | Sort-Object -Property Name | Format-Table -AutoSize | Out-String
-        }
+            LogGroup ' - Installed modules' {
+                Get-InstalledPSResource | Select-Object Name, Version, Prerelease | Sort-Object -Property Name | Format-Table -AutoSize | Out-String
+            }
 
-        LogGroup ' - GitHub connection - Default' {
-            $context = Get-GitHubContext
-            $context | Format-List | Out-String
+            LogGroup ' - GitHub connection - Default' {
+                $context = Get-GitHubContext
+                $context | Format-List | Out-String
 
-            Write-Verbose "Token?    [$([string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token))]"
-            Write-Verbose "AuthType? [$($context.AuthType)] - [$($context.AuthType -ne 'APP')]"
-            Write-Verbose "gh auth?  [$($context.AuthType -ne 'APP' -and -not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token))]"
+                Write-Verbose "Token?    [$([string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token))]"
+                Write-Verbose "AuthType? [$($context.AuthType)] - [$($context.AuthType -ne 'APP')]"
+                Write-Verbose "gh auth?  [$($context.AuthType -ne 'APP' -and -not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token))]"
 
-            if ($context.AuthType -ne 'APP' -and -not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token)) {
-                Write-Output 'GitHub CLI status:'
-                $before = $LASTEXITCODE
-                gh auth status
-                if ($LASTEXITCODE -ne $before) {
-                    Write-Warning "LASTEXITCODE has changed [$LASTEXITCODE]"
-                    $global:LASTEXITCODE = $before
+                if ($context.AuthType -ne 'APP' -and -not [string]::IsNullOrEmpty($env:PSMODULE_GITHUB_SCRIPT_INPUT_Token)) {
+                    Write-Output 'GitHub CLI status:'
+                    $before = $LASTEXITCODE
+                    gh auth status
+                    if ($LASTEXITCODE -ne $before) {
+                        Write-Warning "LASTEXITCODE has changed [$LASTEXITCODE]"
+                        $global:LASTEXITCODE = $before
+                    }
                 }
             }
-        }
 
-        LogGroup ' - GitHub connection - List' {
-            Get-GitHubContext -ListAvailable | Format-Table | Out-String
-        }
+            LogGroup ' - GitHub connection - List' {
+                Get-GitHubContext -ListAvailable | Format-Table | Out-String
+            }
 
-        LogGroup ' - Configuration' {
-            Get-GitHubConfig | Format-List | Out-String
-        }
+            LogGroup ' - Configuration' {
+                Get-GitHubConfig | Format-List | Out-String
+            }
 
-        LogGroup ' - Event Information' {
-            Get-GitHubEventData | Format-List | Out-String
-        }
+            LogGroup ' - Event Information' {
+                Get-GitHubEventData | Format-List | Out-String
+            }
         } # end if ($showInfo)
 
         $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL = 'Pre'

--- a/src/info.ps1
+++ b/src/info.ps1
@@ -59,7 +59,7 @@ process {
             LogGroup ' - Event Information' {
                 Get-GitHubEventData | Format-List | Out-String
             }
-        } # end if ($showInfo)
+        }
 
         & "$PSScriptRoot/ratelimit.ps1"
 

--- a/src/info.ps1
+++ b/src/info.ps1
@@ -61,7 +61,6 @@ process {
             }
         } # end if ($showInfo)
 
-        $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL = 'Pre'
         & "$PSScriptRoot/ratelimit.ps1"
 
         $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'

--- a/src/outputs.ps1
+++ b/src/outputs.ps1
@@ -46,7 +46,7 @@ try {
                 $output.Value | Format-List | Out-String
             }
         }
-    } # end if ($result)
+    }
 
     & "$PSScriptRoot/ratelimit.ps1"
 

--- a/src/outputs.ps1
+++ b/src/outputs.ps1
@@ -16,19 +16,21 @@ try {
     Write-Debug "[$scriptName] - ShowRateLimit: $showRateLimit"
 
     $result = $null
+    $hasResult = $false
     if ($showOutput) {
         $result = (Get-GitHubOutput).result
-        Write-Debug "[$scriptName] - Result: $(-not $result)"
+        $hasResult = [bool]$result
+        Write-Debug "[$scriptName] - ResultPresent: $hasResult"
     }
 
-    if (-not $result -and -not $showRateLimit) {
+    if (-not $hasResult -and -not $showRateLimit) {
         return
     }
 
     $fenceStart = "┏━━┫ $fenceTitle - Outputs ┣━━━━━┓"
     Write-Output $fenceStart
 
-    if ($result) {
+    if ($hasResult) {
         if ([string]::IsNullOrEmpty($env:GITHUB_ACTION)) {
             Write-GitHubWarning 'Outputs cannot be accessed as the step has no ID.'
         }

--- a/src/outputs.ps1
+++ b/src/outputs.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules GitHub
+#Requires -Modules GitHub
 
 [CmdletBinding()]
 param()
@@ -9,18 +9,26 @@ Write-Debug "[$scriptName] - Start"
 try {
     $fenceTitle = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Name
 
-    Write-Debug "[$scriptName] - ShowOutput: $env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowOutput"
-    if ($env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowOutput -ne 'true') {
+    $showOutput = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowOutput -eq 'true'
+    $showRateLimit = $env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowRateLimit -eq 'true'
+
+    Write-Debug "[$scriptName] - ShowOutput: $showOutput"
+    Write-Debug "[$scriptName] - ShowRateLimit: $showRateLimit"
+
+    $result = $null
+    if ($showOutput) {
+        $result = (Get-GitHubOutput).result
+        Write-Debug "[$scriptName] - Result: $(-not $result)"
+    }
+
+    if (-not $result -and -not $showRateLimit) {
         return
     }
 
-    $result = (Get-GitHubOutput).result
-    Write-Debug "[$scriptName] - Result: $(-not $result)"
-    if (-not $result) {
-        return
-    }
     $fenceStart = "┏━━┫ $fenceTitle - Outputs ┣━━━━━┓"
     Write-Output $fenceStart
+
+    if ($result) {
     if ([string]::IsNullOrEmpty($env:GITHUB_ACTION)) {
         Write-GitHubWarning 'Outputs cannot be accessed as the step has no ID.'
     }
@@ -36,6 +44,11 @@ try {
             $output.Value | Format-List | Out-String
         }
     }
+    } # end if ($result)
+
+    $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL = 'Post'
+    & "$PSScriptRoot/ratelimit.ps1"
+
     $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'
     Write-Output $fenceEnd
 } catch {

--- a/src/outputs.ps1
+++ b/src/outputs.ps1
@@ -46,7 +46,6 @@ try {
         }
     } # end if ($result)
 
-    $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL = 'Post'
     & "$PSScriptRoot/ratelimit.ps1"
 
     $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'

--- a/src/outputs.ps1
+++ b/src/outputs.ps1
@@ -1,4 +1,4 @@
-#Requires -Modules GitHub
+﻿#Requires -Modules GitHub
 
 [CmdletBinding()]
 param()
@@ -29,21 +29,21 @@ try {
     Write-Output $fenceStart
 
     if ($result) {
-    if ([string]::IsNullOrEmpty($env:GITHUB_ACTION)) {
-        Write-GitHubWarning 'Outputs cannot be accessed as the step has no ID.'
-    }
-
-    if (-not (Test-Path -Path $env:GITHUB_OUTPUT)) {
-        Write-Warning "File not found: $env:GITHUB_OUTPUT"
-    }
-
-    foreach ($output in $result.PSObject.Properties) {
-        $blue = $PSStyle.Foreground.Blue
-        $reset = $PSStyle.Reset
-        LogGroup " - $blue$($output.Name)$reset" {
-            $output.Value | Format-List | Out-String
+        if ([string]::IsNullOrEmpty($env:GITHUB_ACTION)) {
+            Write-GitHubWarning 'Outputs cannot be accessed as the step has no ID.'
         }
-    }
+
+        if (-not (Test-Path -Path $env:GITHUB_OUTPUT)) {
+            Write-Warning "File not found: $env:GITHUB_OUTPUT"
+        }
+
+        foreach ($output in $result.PSObject.Properties) {
+            $blue = $PSStyle.Foreground.Blue
+            $reset = $PSStyle.Reset
+            LogGroup " - $blue$($output.Name)$reset" {
+                $output.Value | Format-List | Out-String
+            }
+        }
     } # end if ($result)
 
     $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL = 'Post'

--- a/src/ratelimit.ps1
+++ b/src/ratelimit.ps1
@@ -11,7 +11,9 @@ $label = $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL
 
 LogGroup " - Rate Limit ($label)" {
     try {
-        Get-GitHubRateLimit | Format-Table -AutoSize | Out-String
+        Get-GitHubRateLimit -ErrorAction Stop |
+            Select-Object Name, Limit, Used, Remaining, ResetsAt, ResetsIn |
+            Format-Table -AutoSize | Out-String
     } catch {
         Write-Warning "Could not retrieve rate limit information: $($_.Exception.Message)"
     }

--- a/src/ratelimit.ps1
+++ b/src/ratelimit.ps1
@@ -1,0 +1,30 @@
+#Requires -Modules GitHub
+
+[CmdletBinding()]
+param()
+
+$scriptName = $MyInvocation.MyCommand.Name
+Write-Debug "[$scriptName] - Start"
+
+try {
+    if ($env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowRateLimit -ne 'true') {
+        return
+    }
+
+    $fenceTitle = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Name
+    $label = $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL
+
+    $fenceStart = "┏━━┫ $fenceTitle - Rate Limit ($label) ┣━━━━━━━━┓"
+    Write-Output $fenceStart
+
+    LogGroup " - Rate Limit ($label)" {
+        Get-GitHubRateLimit | Format-Table -AutoSize | Out-String
+    }
+
+    $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'
+    Write-Output $fenceEnd
+} catch {
+    throw $_
+}
+
+Write-Debug "[$scriptName] - End"

--- a/src/ratelimit.ps1
+++ b/src/ratelimit.ps1
@@ -18,7 +18,11 @@ try {
     Write-Output $fenceStart
 
     LogGroup " - Rate Limit ($label)" {
-        Get-GitHubRateLimit | Format-Table -AutoSize | Out-String
+        try {
+            Get-GitHubRateLimit | Format-Table -AutoSize | Out-String
+        } catch {
+            Write-Warning "Could not retrieve rate limit information: $($_.Exception.Message)"
+        }
     }
 
     $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'

--- a/src/ratelimit.ps1
+++ b/src/ratelimit.ps1
@@ -6,7 +6,7 @@ if ($env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowRateLimit -ne 'true') {
     return
 }
 
-LogGroup ' - Rate Limit' {
+LogGroup ' - Rate Limits' {
     try {
         Get-GitHubRateLimit -ErrorAction Stop |
             Select-Object Name, Limit, Used, Remaining, ResetsAt, ResetsIn |

--- a/src/ratelimit.ps1
+++ b/src/ratelimit.ps1
@@ -1,15 +1,12 @@
 #Requires -Modules GitHub
 
 # Helper script - called from info.ps1 and outputs.ps1 to display rate limit information.
-# Expects $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL to be set to 'Pre' or 'Post'.
 
 if ($env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowRateLimit -ne 'true') {
     return
 }
 
-$label = $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL
-
-LogGroup " - Rate Limit ($label)" {
+LogGroup ' - Rate Limit' {
     try {
         Get-GitHubRateLimit -ErrorAction Stop |
             Select-Object Name, Limit, Used, Remaining, ResetsAt, ResetsIn |

--- a/src/ratelimit.ps1
+++ b/src/ratelimit.ps1
@@ -1,34 +1,18 @@
 #Requires -Modules GitHub
 
-[CmdletBinding()]
-param()
+# Helper script - called from info.ps1 and outputs.ps1 to display rate limit information.
+# Expects $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL to be set to 'Pre' or 'Post'.
 
-$scriptName = $MyInvocation.MyCommand.Name
-Write-Debug "[$scriptName] - Start"
-
-try {
-    if ($env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowRateLimit -ne 'true') {
-        return
-    }
-
-    $fenceTitle = $env:PSMODULE_GITHUB_SCRIPT_INPUT_Name
-    $label = $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL
-
-    $fenceStart = "┏━━┫ $fenceTitle - Rate Limit ($label) ┣━━━━━━━━┓"
-    Write-Output $fenceStart
-
-    LogGroup " - Rate Limit ($label)" {
-        try {
-            Get-GitHubRateLimit | Format-Table -AutoSize | Out-String
-        } catch {
-            Write-Warning "Could not retrieve rate limit information: $($_.Exception.Message)"
-        }
-    }
-
-    $fenceEnd = '┗' + ('━' * ($fenceStart.Length - 2)) + '┛'
-    Write-Output $fenceEnd
-} catch {
-    throw $_
+if ($env:PSMODULE_GITHUB_SCRIPT_INPUT_ShowRateLimit -ne 'true') {
+    return
 }
 
-Write-Debug "[$scriptName] - End"
+$label = $env:PSMODULE_GITHUB_SCRIPT_RATELIMIT_LABEL
+
+LogGroup " - Rate Limit ($label)" {
+    try {
+        Get-GitHubRateLimit | Format-Table -AutoSize | Out-String
+    } catch {
+        Write-Warning "Could not retrieve rate limit information: $($_.Exception.Message)"
+    }
+}


### PR DESCRIPTION
GitHub API rate limit consumption is now visible directly in the action logs. When enabled, rate limit details - including remaining quota, limit, used count, and reset time for all resource categories - are displayed before and after the user script runs, making it easy to see exactly how many API calls a workflow step consumed.

- Fixes #88

## New: Rate limit visibility in action logs

A new `ShowRateLimit` input (default: `'false'`) controls whether rate limit information appears in the logs. When set to `'true'`, a **Rate Limits** LogGroup appears inside the Info fence before the user script, and another **Rate Limits** LogGroup appears inside the Outputs fence after it.

```yaml
- uses: PSModule/GitHub-Script@v1
  with:
    ShowRateLimit: 'true'
    Script: |
      Get-GitHubRepository -Owner PSModule -Name GitHub-Script
```

The output includes a formatted table of all resource categories returned by `Get-GitHubRateLimit` (core, search, graphql, etc.), each showing `Limit`, `Used`, `Remaining`, `ResetsAt`, and `ResetsIn`.

When the input is omitted or set to `'false'` (the default), no rate limit output appears.

If `ShowRateLimit` is enabled but `ShowInfo` or `ShowOutput` is off, the corresponding fence still renders with just the rate limit content inside. For auth types that do not support `Get-GitHubRateLimit` (for example GitHub App contexts), a warning is shown instead of failing.

## Technical Details

- Added `ShowRateLimit` input to `action.yml` with `required: false` and `default: 'false'`.
- Added `PSMODULE_GITHUB_SCRIPT_INPUT_ShowRateLimit` environment variable to the composite step.
- Created `src/ratelimit.ps1` as a helper script (no fence borders) that checks the guard and renders a single `Rate Limits` LogGroup.
- `src/ratelimit.ps1` now calls `Get-GitHubRateLimit -ErrorAction Stop` so non-terminating errors are caught reliably in unsupported auth contexts.
- `src/ratelimit.ps1` explicitly selects `Name`, `Limit`, `Used`, `Remaining`, `ResetsAt`, and `ResetsIn` before formatting to keep columns deterministic.
- Modified `src/info.ps1`: adjusted the early-return guard to also consider `ShowRateLimit`, wrapped existing LogGroups in `if ($showInfo)`, and calls `ratelimit.ps1` before the fence close.
- Modified `src/outputs.ps1`: adjusted the early-return guard to also consider `ShowRateLimit`, wrapped existing output LogGroups in `if ($result)`, and calls `ratelimit.ps1` before the fence close.
- The `action.yml` run block remains in the same flow, while `info.ps1` and `outputs.ps1` invoke the helper internally.
- Enabled `ShowRateLimit: true` across all Action-Test scenarios in `.github/workflows/TestWorkflow.yml`, including Basic, WithScript path variants, Commands + Outputs, Matrix Creator, WithoutToken, WithPAT, WithUserFGPAT, WithOrgFGPAT, GitHubAppEnt, GitHubAppOrg + quoted inputs, WithKeyVaultKeyReference, WithKeyVaultKeyReferenceLatest, and PreserveCredentials False.
