### PR TITLE
⚙️ [Maintenance]: Remove unsupported zizmor secrets allowlist config

### DIFF
--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -2,16 +2,3 @@ rules:
   template-injection:
     ignore:
       - action.yml
-
-  secrets-outside-env:
-    # These test credentials are intentionally managed as organization-level
-    # secrets for reusable test workflows across repositories.
-    config:
-      allow:
-        - TEST_USER_PAT
-        - TEST_USER_USER_FG_PAT
-        - TEST_USER_ORG_FG_PAT
-        - TEST_APP_ENT_CLIENT_ID
-        - TEST_APP_ENT_PRIVATE_KEY
-        - TEST_APP_ORG_CLIENT_ID
-        - TEST_APP_ORG_PRIVATE_KEY


### PR DESCRIPTION
This removes stale `secrets-outside-env` allowlist configuration from the zizmor config so the workflow uses only suppression mechanisms supported by the current Super-Linter/zizmor version.

## Changed: zizmor configuration cleanup

The repository no longer carries the unsupported `rules.secrets-outside-env.config.allow` block in `.github/linters/zizmor.yaml`.

This avoids keeping dead configuration that cannot be applied by the currently bundled zizmor version and keeps the linter config aligned with actual runtime behavior.

## Technical Details

- Removed the `rules.secrets-outside-env.config.allow` section and its test secret entries from `.github/linters/zizmor.yaml`.
- Kept existing `template-injection` ignore settings unchanged.
- No functional action/runtime behavior was changed; this is a linter-config maintenance cleanup.